### PR TITLE
Pin torch to 1.8.1

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,4 +7,5 @@ pytest
 pytorch-lightning==1.2.10
 lightning-bolts==0.3.3
 ray[tune]
+torch==1.8.1
 torchvision


### PR DESCRIPTION
lightning-bolts does not work with Torch 1.9. We should pin torch to 1.8.1 until the next lightining-bolts release. This will fix the CI failures in the other PRs.