### PR TITLE
Fix Tune GPU Checkpointing

### DIFF
--- a/ray_lightning/ray_ddp.py
+++ b/ray_lightning/ray_ddp.py
@@ -1,4 +1,3 @@
-import io
 from typing import Callable, Dict, List, Union, Any
 
 import os
@@ -16,7 +15,8 @@ from ray.util.sgd.utils import find_free_port
 from ray.util.queue import Queue
 
 from ray_lightning.session import init_session
-from ray_lightning.util import process_results
+from ray_lightning.util import process_results, to_state_stream, \
+    load_state_stream
 from ray_lightning.tune import TUNE_INSTALLED, is_session_enabled
 from ray_lightning.ray_environment import RayEnvironment
 
@@ -166,15 +166,6 @@ class RayPlugin(DDPSpawnPlugin):
         values = [os.getenv(k) for k in keys]
         ray.get([w.set_env_vars.remote(keys, values) for w in self.workers])
 
-    def _load_state_stream(self, state_stream):
-        _buffer = io.BytesIO(state_stream)
-        to_gpu = self.use_gpu and torch.cuda.is_available()
-        state_dict = torch.load(
-            _buffer,
-            map_location=("cpu" if not to_gpu
-                          else lambda storage, loc: storage.cuda()))
-        return state_dict
-
     def execution_loop(self, trainer, tune_enabled: bool = True):
         """Main execution loop for training, testing, & prediction.
 
@@ -209,7 +200,7 @@ class RayPlugin(DDPSpawnPlugin):
         results = process_results(futures, queue)
         # Get the results, checkpoint path, and model weights from worker 0.
         results, best_path, state_stream = results[0]
-        state_dict = self._load_state_stream(state_stream)
+        state_dict = load_state_stream(state_stream, to_gpu=self.use_gpu)
         # Set the state for PTL using the output from remote training.
         self._results = results
         self._model = model
@@ -340,18 +331,13 @@ class RayPlugin(DDPSpawnPlugin):
         else:
             return torch.device("cpu")
 
-    def _to_state_stream(self, model_state_dict):
-        _buffer = io.BytesIO()
-        torch.save(model_state_dict, _buffer)
-        return _buffer.getvalue()
-
     def transfer_distrib_spawn_state_on_fit_end(self, results):
         """Sets the training output as attributes so it can be retrieved."""
         if self.global_rank == 0:
             # Save training results as attributes.
             self._results = results
             self.model_state_stream = \
-                self._to_state_stream(self.lightning_module.state_dict())
+                to_state_stream(self.lightning_module.state_dict())
             best_model_path = None
             if self.lightning_module.trainer.checkpoint_callback is not None:
                 best_model_path = \

--- a/ray_lightning/tests/test_tune.py
+++ b/ray_lightning/tests/test_tune.py
@@ -2,6 +2,7 @@ import os
 import pytest
 
 import ray
+import torch
 from ray import tune
 
 from ray_lightning import RayPlugin, HorovodRayPlugin
@@ -81,6 +82,22 @@ def test_checkpoint_ddp(tmpdir, ray_start_4_cpus):
 
 
 def test_checkpoint_horovod(tmpdir, ray_start_4_cpus):
+    """Tests if Tune checkpointing works with HorovodRayAccelerator."""
+    plugin = HorovodRayPlugin(num_hosts=1, num_slots=2, use_gpu=False)
+    checkpoint_test(tmpdir, plugin)
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="test requires multi-GPU machine")
+def test_checkpoint_ddp_gpu(tmpdir, ray_start_4_cpus):
+    """Tests if Tune checkpointing works with RayAccelerator."""
+    plugin = RayPlugin(num_workers=2, use_gpu=False)
+    checkpoint_test(tmpdir, plugin)
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="test requires multi-GPU machine")
+def test_checkpoint_horovod_gpu(tmpdir, ray_start_4_cpus):
     """Tests if Tune checkpointing works with HorovodRayAccelerator."""
     plugin = HorovodRayPlugin(num_hosts=1, num_slots=2, use_gpu=False)
     checkpoint_test(tmpdir, plugin)

--- a/ray_lightning/util.py
+++ b/ray_lightning/util.py
@@ -63,7 +63,11 @@ def to_state_stream(model_state_dict):
 
 
 def load_state_stream(state_stream, to_gpu):
-    """Converts the state stream to a state dict on the appropriate device."""
+    """Converts the state stream to a state dict on the appropriate device.
+
+    Converts to GPU if ``to_gpu`` is True and CUDA is available.
+
+    """
     _buffer = io.BytesIO(state_stream)
     to_gpu = to_gpu and torch.cuda.is_available()
     state_dict = torch.load(

--- a/ray_lightning/util.py
+++ b/ray_lightning/util.py
@@ -1,5 +1,7 @@
+import io
 from typing import Callable
 
+import torch
 from pytorch_lightning.accelerators import GPUAccelerator
 from pytorch_lightning import Trainer, LightningModule
 
@@ -49,3 +51,21 @@ def process_results(training_result_futures, queue):
         # Process any remaining items in queue.
         _handle_queue(queue)
     return ray.get(training_result_futures)
+
+
+def to_state_stream(model_state_dict):
+    """Converts the given state dict to a stream of bytes."""
+    _buffer = io.BytesIO()
+    torch.save(model_state_dict, _buffer)
+    return _buffer.getvalue()
+
+
+def load_state_stream(state_stream, to_gpu):
+    """Converts the state stream to a state dict on the appropriate device."""
+    _buffer = io.BytesIO(state_stream)
+    to_gpu = to_gpu and torch.cuda.is_available()
+    state_dict = torch.load(
+        _buffer,
+        map_location=("cpu"
+                      if not to_gpu else lambda storage, loc: storage.cuda()))
+    return state_dict


### PR DESCRIPTION
Closes https://github.com/ray-project/ray_lightning/issues/38

When using the Tune Checkpoint Callback, the model state dict is passed from the worker to the driver. However, the driver might not have GPU available causing deserialization errors if the workers are training with GPU. Thus, we should convert the model state dict to bytes first before passing it over.