### PR TITLE
Bump to v0.1.2 for development

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name="ray_lightning",
     packages=find_packages(where=".", include="ray_lightning*"),
-    version="0.1.1",
+    version="0.1.2",
     author="Ray Team",
     description="Ray distributed plugins for Pytorch Lightning.",
     long_description="Custom Pytorch Lightning distributed plugins "


### PR DESCRIPTION
Ray Lightning 0.1.1 was released today, so this bumps up the development version to 0.1.2