### PR TITLE
Example: fix ray_ddp_example.py with GPU usage

### DIFF
--- a/ray_lightning/examples/ray_ddp_example.py
+++ b/ray_lightning/examples/ray_ddp_example.py
@@ -73,6 +73,7 @@ def train_mnist(config,
     trainer = pl.Trainer(
         max_epochs=num_epochs,
         callbacks=callbacks,
+        gpus=1 if use_gpu else 0,
         plugins=[RayPlugin(num_workers=num_workers, use_gpu=use_gpu)],
         **trainer_kwargs)
     trainer.fit(model)


### PR DESCRIPTION
Require gpus>0 to enable GPUs.