### PR TITLE
Tear down workers after a trial is terminated by a scheduler

### DIFF
--- a/ray_lightning/launchers/ray_launcher.py
+++ b/ray_lightning/launchers/ray_launcher.py
@@ -55,17 +55,19 @@ class RayLauncher(_Launcher):
         This function is run on the driver process.
         """
         self.setup_workers()
-        ray_output = self.run_function_on_workers(
-            function, *args, trainer=trainer, **kwargs)
+        try:
+            ray_output = self.run_function_on_workers(
+                function, *args, trainer=trainer, **kwargs)
 
-        if trainer is None:
-            raise NotImplementedError(
-                "Ray launcher does not support trainer is None!")
-        self._recover_results_in_main_process(ray_output, trainer)
-        return_value = ray_output.trainer_results
+            if trainer is None:
+                raise NotImplementedError(
+                    "Ray launcher does not support trainer is None!")
+            self._recover_results_in_main_process(ray_output, trainer)
+            return_value = ray_output.trainer_results
+        finally:
+            self.teardown_workers()
+            self._strategy.teardown()
 
-        self.teardown_workers()
-        self._strategy.teardown()
         return return_value
 
     def setup_workers(self, tune_enabled: bool = True) -> None:


### PR DESCRIPTION
Fixes #253

In the end, I figured out, that when a scheduler terminates a trial, we do not tear down the corresponding workers, and the necessary resources are not available for the subsequent trials.

The proposed solution works for my use case but feels very hacky. Maybe someone with a deeper knowledge about the inner workings of ray tune can come up with a more elegant solution.

Let me know what you think!